### PR TITLE
Define ResultMetada before usage

### DIFF
--- a/rest.raml
+++ b/rest.raml
@@ -3,8 +3,8 @@ usage: Used in RESTful APIs
 
 types:
   Money: !include rest/types/money.raml
-  Result: !include rest/types/result.raml
   ResultMetadata: !include rest/types/result-metadata.raml
+  Result: !include rest/types/result.raml
 traits:
   Filter: !include rest/traits/filter.raml
 

--- a/rest.raml
+++ b/rest.raml
@@ -3,7 +3,7 @@ usage: Used in RESTful APIs
 
 types:
   Money: !include rest/types/money.raml
-  ResultMetadata: !include rest/types/result-metadata.raml
+  Paysera.ResultMetadata: !include rest/types/result-metadata.raml
   Result: !include rest/types/result.raml
 traits:
   Filter: !include rest/traits/filter.raml

--- a/rest.raml
+++ b/rest.raml
@@ -3,7 +3,7 @@ usage: Used in RESTful APIs
 
 types:
   Money: !include rest/types/money.raml
-  Paysera.ResultMetadata: !include rest/types/result-metadata.raml
+  ResultMetadata: !include rest/types/result-metadata.raml
   Result: !include rest/types/result.raml
 traits:
   Filter: !include rest/traits/filter.raml

--- a/rest/types/result.raml
+++ b/rest/types/result.raml
@@ -4,4 +4,4 @@ displayName: Result of some objects
 properties:
   _metadata:
     required: true
-    type: ResultMetadata
+    type: Paysera.ResultMetadata

--- a/rest/types/result.raml
+++ b/rest/types/result.raml
@@ -4,4 +4,4 @@ displayName: Result of some objects
 properties:
   _metadata:
     required: true
-    type: Paysera.ResultMetadata
+    type: ResultMetadata


### PR DESCRIPTION
ResultMetadata type is used in result.raml. Should be defined before the usage